### PR TITLE
feat(share) Add post share and copy link functionality

### DIFF
--- a/client/src/components/post/Post.tsx
+++ b/client/src/components/post/Post.tsx
@@ -1,22 +1,27 @@
 import { useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAngleUp, faAngleDown } from "@fortawesome/free-solid-svg-icons";
 import {
   faComment,
   faBookmark,
   faShareFromSquare,
 } from "@fortawesome/free-regular-svg-icons";
-import { faAngleUp, faAngleDown } from "@fortawesome/free-solid-svg-icons";
 
-import { postActions } from "../../redux/slices/post";
-import { Post } from "../../type/types";
 import CommentForm from "../forms/CommentForm";
+import ShareButtons from "../share/ShareButtons";
+import { postActions } from "../../redux/slices/post";
+import { RootState } from "../../redux/store";
+import { Post } from "../../type/types";
 
 type Props = {
   post: Post;
 };
 
 function PostItem({ post }: Props) {
+  const showShareModal = useSelector(
+    (state: RootState) => state.posts.showShareModal[post._id] || false
+  );
   const [isSaved, setIsSaved] = useState(false);
   const [showComments, setShowComments] = useState(false);
 
@@ -34,6 +39,10 @@ function PostItem({ post }: Props) {
 
   const toggleCommentSection = () => {
     setShowComments(!showComments);
+  };
+
+  const handleShareClick = () => {
+    dispatch(postActions.setShowShareModal({ [post._id]: true }));
   };
 
   return (
@@ -73,7 +82,7 @@ function PostItem({ post }: Props) {
                 Comment
               </button>
 
-              <button className="text-gray-600 ml-4">
+              <button className="text-gray-600 ml-4" onClick={handleShareClick}>
                 <FontAwesomeIcon
                   icon={faShareFromSquare}
                   className="w-40 h-40 mr-2"
@@ -91,6 +100,7 @@ function PostItem({ post }: Props) {
             </div>
           </div>
         </div>
+        {showShareModal && <ShareButtons post={post} />}
         {showComments && <CommentForm />}
       </div>
     </div>

--- a/client/src/components/post/PostSection.tsx
+++ b/client/src/components/post/PostSection.tsx
@@ -60,7 +60,7 @@ const posts = [
     author: "Mustafa",
   },
   {
-    _id: "1",
+    _id: "4",
     postTitle:
       "Building a Real-time Chat Application with Full-Stack Development",
     timestamp: "1",
@@ -77,7 +77,7 @@ const posts = [
     author: "Habeeb",
   },
   {
-    _id: "2",
+    _id: "5",
     postTitle: "Scaling Your Full-Stack Web App: Best Practices and Strategies",
     timestamp: "8",
     content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -94,7 +94,7 @@ const posts = [
   },
 
   {
-    _id: "3",
+    _id: "6",
     postTitle: "Secure Coding Practices for Full-Stack Developers",
     timestamp: "24",
     content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/client/src/components/share/ShareButtons.tsx
+++ b/client/src/components/share/ShareButtons.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { useDispatch } from "react-redux";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEnvelope, faTimes } from "@fortawesome/free-solid-svg-icons";
+import {
+  faSquareXTwitter,
+  faFacebook,
+} from "@fortawesome/free-brands-svg-icons";
+import { faCopy } from "@fortawesome/free-regular-svg-icons";
+
+import { postActions } from "../../redux/slices/post";
+import { Post } from "../../type/types";
+
+type Props = {
+  post: Post;
+};
+
+function ShareButtons({ post }: Props) {
+  const [isTooltipVisible, setTooltipVisible] = useState(false);
+
+  const dispatch = useDispatch();
+
+  const handleShareClick = () => {
+    dispatch(postActions.setShowShareModal({ [post._id]: false }));
+  };
+
+  const shareToTwitter = (post: Post) => {
+    const postURL = encodeURIComponent(window.location.href);
+    const tweetText = encodeURIComponent(
+      `Check out this project: ${post.postTitle}`
+    );
+    const twitterShareUrl = `https://twitter.com/intent/tweet?url=${postURL}&text=${tweetText}`;
+    window.open(twitterShareUrl, "_blank");
+  };
+
+  const shareToFacebook = () => {
+    const postURL = encodeURIComponent(window.location.href);
+    const facebookText = encodeURIComponent(
+      `Check out this project: ${post.postTitle}`
+    );
+    const facebookShareURL = `https://www.facebook.com/sharer/sharer.php?u=${postURL}&title=${facebookText}`;
+    window.open(facebookShareURL, "_blank");
+  };
+
+  const shareViaEmail = () => {
+    const postURL = window.location.href;
+    const emailSubject = "Check out this project";
+    const emailBody = `I found this interesting project: ${postURL}`;
+    const emailLink = `mailto:?subject=${encodeURIComponent(
+      emailSubject
+    )}&body=${encodeURIComponent(emailBody)}`;
+    window.location.href = emailLink;
+  };
+
+  const copyPostLink = () => {
+    const currentURL = window.location.href;
+    navigator.clipboard
+      .writeText(currentURL)
+      .then(() => {
+        setTooltipVisible(true);
+        setTimeout(() => {
+          setTooltipVisible(false);
+        }, 2000);
+      })
+      .catch((error) => {
+        console.error("Failed to copy link: ", error);
+      });
+  };
+
+  return (
+    <div className="relative inset-0 flex items-center justify-center">
+      <div className="bg-white w-[368px] p-2 rounded shadow-lg absolute right-32 bottom-12">
+        <button
+          className="w-6 h-6 text-gray-600 absolute top-2 right-2 rounded-full"
+          onClick={handleShareClick}
+        >
+          <FontAwesomeIcon icon={faTimes} className="w-6 h-6" />
+        </button>
+        <h3 className="text-lg font-semibold  mb-2">Share to...</h3>
+        {isTooltipVisible && (
+          <div className="absolute left-36 bottom-10 tooltip">Link Copied!</div>
+        )}
+        <div className="flex flex-row space-x-4">
+          {/* twitter share button */}
+          <div>
+            <button className="text-black" onClick={() => shareToTwitter(post)}>
+              <FontAwesomeIcon icon={faSquareXTwitter} /> Twitter
+            </button>
+          </div>
+          {/* facebook share button */}
+          <div>
+            <button
+              className="text-[#1877F2]"
+              onClick={() => shareToFacebook()}
+            >
+              <FontAwesomeIcon icon={faFacebook} /> Facebook
+            </button>
+          </div>
+
+          {/* email share button */}
+          <div>
+            <button className="text-[#D44638]" onClick={() => shareViaEmail()}>
+              <FontAwesomeIcon icon={faEnvelope} /> Email
+            </button>
+          </div>
+          <div>
+            <button className="text-black" onClick={copyPostLink}>
+              <FontAwesomeIcon icon={faCopy} /> Copy Link
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ShareButtons;

--- a/client/src/redux/slices/post.ts
+++ b/client/src/redux/slices/post.ts
@@ -4,10 +4,12 @@ import { Post } from "../../type/types";
 
 type PostState = {
   posts: Post[];
+  showShareModal: { [postId: string]: boolean };
 };
 
 const initialState: PostState = {
   posts: [],
+  showShareModal: {},
 };
 
 const postsSlice = createSlice({
@@ -16,6 +18,9 @@ const postsSlice = createSlice({
   reducers: {
     addPost: (state, action) => {
       state.posts.unshift(action.payload);
+    },
+    setShowShareModal: (state, action) => {
+      state.showShareModal = action.payload;
     },
   },
 });


### PR DESCRIPTION
This commit adds the ability for user to easily share post on social media such as twitter and facebook, and via email. It also provides a convenient way to copy the post link